### PR TITLE
added manual reload attribute.  Optional feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,33 @@ $scope.options = {
     disableColumnSelection: true // default false
 };
 ```
+Declare a manual reload function in your controller and assign it to reload attribute on the directive. Optional.
+```
+<!-- in html -->
+<angular-dayparts options="options" reload="reload"></angular-dayparts>
+```
+
+```
+/*in controller*/
+$scope.reload;
+$scope.options.selected = ['monday-14', 'monday-15'];
+
+function changeSelected() {
+    //update selected
+    $scope.options.selected = ['monday-14', 'monday-16']
+    //reload
+    if ($scope.reload) {
+        $scope.reload();
+    }
+}
+
+```
 
 
 Call the directive from your page
 
 ```html
-<angular-dayparts options="options"></angular-dayparts>
+<angular-dayparts options="options" reload="reload"></angular-dayparts>
 ```
 
 

--- a/dist/angular-dayparts.js
+++ b/dist/angular-dayparts.js
@@ -3,7 +3,8 @@ angular.module('angular-dayparts', [])
     return {
         restrict: 'E',
         scope: {
-            options: '=?'
+            options: '=?',
+            reload: '='
         },
         templateUrl: 'template.html',
         controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
@@ -25,6 +26,14 @@ angular.module('angular-dayparts', [])
                 $timeout(function(){
                     repopulate($scope.options.selected);
                 }, 100);
+            }
+
+            /**
+             * Clears all hours and rereads the selected option
+             */
+            $scope.reload = function() {
+              $scope.reset();
+              repopulate();
             }
 
 

--- a/src/angular-dayparts.js
+++ b/src/angular-dayparts.js
@@ -3,7 +3,8 @@ angular.module('angular-dayparts', [])
     return {
         restrict: 'E',
         scope: {
-            options: '=?'
+            options: '=?',
+            reload: '='
         },
         templateUrl: 'template.html',
         controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
@@ -25,6 +26,14 @@ angular.module('angular-dayparts', [])
                 $timeout(function(){
                     repopulate($scope.options.selected);
                 }, 100);
+            }
+
+            /**
+             * Clears all hours and rereads the selected option
+             */
+            $scope.reload = function() {
+              $scope.reset();
+              repopulate();
             }
 
 


### PR DESCRIPTION
I noticed that when the $scope.options.selected array changed after initial load the angular-dayparts directive does not represent the change.  I added a reload function that tells the angular-dayparts directive reread the selected array.